### PR TITLE
Fixes overlapping news items

### DIFF
--- a/css/rssReader.css
+++ b/css/rssReader.css
@@ -22,6 +22,18 @@
 #rssreader .rssItem {
     padding-top: 10px;
     line-height: 18px;
+    width: 316px;
+    float: left;
+}
+
+#rssreader .rssItemThumbnail {
+    width: 102px;
+    float: left;
+}
+
+#rssreader .rssItemContent {
+    width: 214px;
+    float: right;
 }
 
 #rssreader .pubDate {
@@ -33,7 +45,6 @@
 }
 
 #rssreader img {
-    float: left;
     vertical-align: top;
     height: 48px;
     padding-right: 5px;


### PR DESCRIPTION
- Specify widths of thumbnail and content
- Thumbnail floats left and content floats right so they stay next to
  each other.
- Each item, which is the full width of the reader is floated left so
  they do not overlap.
